### PR TITLE
Fix hostname discovery for platform=none to support all AWS regions

### DIFF
--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -419,21 +419,24 @@ function write_none_tfvars() {
 
     local tfvars_file="${templates_dir}/terraform.auto.tfvars"
 
-    # Get Linux node information for platform "none" (UPI/baremetal on AWS)
-    local linux_node=$(oc get nodes -l "node-role.kubernetes.io/worker,windowsmachineconfig.openshift.io/byoh!=true" -o=jsonpath="{.items[0].status.addresses[?(@.type=='Hostname')].address}")
+    # Get Linux worker node FQDN for platform "none" (UPI/baremetal)
+    # Try InternalDNS first (set by cloud controller manager with correct region-specific format)
+    local win_machine_hostname=$(oc get nodes -l "node-role.kubernetes.io/worker,windowsmachineconfig.openshift.io/byoh!=true" -o=jsonpath="{.items[0].status.addresses[?(@.type=='InternalDNS')].address}")
 
-    # Construct full DNS name or resolve it via nslookup
-    local win_machine_hostname
+    # Fallback to metadata.name if InternalDNS not available (e.g., UPI clusters)
+    if [[ -z "$win_machine_hostname" ]]; then
+        win_machine_hostname=$(oc get nodes -l "node-role.kubernetes.io/worker,windowsmachineconfig.openshift.io/byoh!=true" -o=jsonpath="{.items[0].metadata.name}")
+    fi
+
+    # Extract region from FQDN or use AWS_DEFAULT_REGION config
     local region
-    if [[ -n "${AWS_REGION:-}" ]]; then
-        # Use AWS_REGION if set
-        region="${AWS_REGION}"
-        win_machine_hostname="${linux_node}.${region}.compute.internal"
+    if [[ "$win_machine_hostname" =~ \.([^.]+)\.compute\.internal$ ]]; then
+        # Standard AWS regions: ip-10-x-x-x.<region>.compute.internal
+        region="${BASH_REMATCH[1]}"
     else
-        # Otherwise, resolve via nslookup
-        local ip_linux_node=$(oc get node ${linux_node} -o=jsonpath="{.status.addresses[?(@.type=='InternalIP')].address}")
-        win_machine_hostname=$(oc debug node/${linux_node} -- nslookup ${ip_linux_node} 2>/dev/null | grep -oP 'name = \K[^.]*.*' | sed 's/\.$//')
-        region=$(echo "${win_machine_hostname}" | cut -d "." -f2)
+        # us-east-1 uses .ec2.internal (no region in domain)
+        # Or FQDN doesn't match expected pattern - use config
+        region=$(get_config "AWS_DEFAULT_REGION" "us-east-1")
     fi
 
     local admin_username=$(get_user_name "none")


### PR DESCRIPTION
## Summary
Fix hostname discovery for platform "none" (UPI/baremetal) to support all AWS regions generically.

## Problem
The current code constructs AWS FQDN as:
```bash
win_machine_hostname="${linux_node}.${region}.compute.internal"
```

This breaks for us-east-1 which uses `.ec2.internal` instead of `.compute.internal`, requiring hardcoded special-case logic.

## Solution
Use Kubernetes-provided FQDN instead of constructing it:

1. **Try InternalDNS first** - AWS Cloud Controller Manager sets this correctly for all regions
2. **Fallback to metadata.name** - Node name is already FQDN in AWS UPI clusters  
3. **Extract region from FQDN** - Parse from domain name if available
4. **Use AWS_DEFAULT_REGION config** - For `.ec2.internal` format (region not in domain)

## Benefits
✅ **Generic** - Works for all current and future AWS regions  
✅ **No hardcoded regions** - Uses AWS-provided data or configuration  
✅ **Graceful fallback** - Uses metadata.name if InternalDNS unavailable  
✅ **Fixes Prow CI** - AWS UPI Windows BYOH provisioning now works  

## Scope
- **Affects:** Platform "none" only (UPI/baremetal workflows)  
- **Does not affect:** Platform "aws" (IPI with MachineSets - different code path)

## Testing
Tested with openshift/release PR for AWS UPI Windows BYOH jobs.

## Related
- openshift/release#74742 - AWS UPI Windows Containers CI jobs (depends on this fix)