### PR TITLE
Auto-detect UPI clusters and use platform=none

### DIFF
--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -14,6 +14,14 @@ function get_platform() {
         error "Failed to detect platform from cluster"
     fi
 
+    # Auto-detect UPI clusters: If no Machine API, use "none" platform
+    # UPI clusters (any platform) don't have Machine API machines
+    # The "none" platform is designed for manual/BYOH provisioning without data source queries
+    if ! oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=worker --no-headers 2>/dev/null | grep -q .; then
+        log "UPI cluster detected (no Machine API), using platform=none for BYOH provisioning"
+        platform="none"
+    fi
+
     if [[ ! " ${SUPPORTED_PLATFORMS[@]} " =~ " ${platform} " ]]; then
         error "Platform ${platform} not supported. Supported platforms: ${SUPPORTED_PLATFORMS[*]}"
     fi


### PR DESCRIPTION
## Problem

UPI (User-Provisioned Infrastructure) clusters report their actual platform (AWS, Azure, GCP, etc.) via `infrastructure.status.platformStatus.type`, but they **don't have Machine API machines**.

When terraform-windows-provisioner detects platform="aws" for a UPI cluster, it tries to use `aws/main.tf` which queries AWS data sources:
```hcl
data "aws_instance" "winc-machine-node" {
  filter {
    name    = "private-dns-name"
    values  = [var.winc_machine_hostname]
  }
  ...
}
```

This fails because:
- UPI doesn't provision via Terraform/CloudFormation with consistent tagging
- Instance tagging may differ from IPI clusters
- No guarantee the hostname matches AWS private-dns-name format

## Solution

Add **generic UPI detection** to `get_platform()`:
- Check if Machine API has worker machines
- If NO machines exist → UPI cluster → use platform="none"
- Works for **any platform** (AWS, Azure, GCP, vSphere, Nutanix)

The "none" platform is designed for bare metal / manual provisioning and doesn't query infrastructure data sources.

## Benefits

- ✅ Generic solution works for UPI on ANY cloud platform
- ✅ No platform-specific logic needed
- ✅ No manual configuration required by users
- ✅ Enables CI workflows like `aws-upi-ovn-winc` to provision Windows BYOH nodes

## Testing

- ✅ IPI clusters: Machine API exists → uses original platform (aws/azure/gcp/etc.)
- ✅ UPI clusters: No Machine API → automatically uses platform=none
- Tested with AWS UPI cluster in openshift/release CI

## Related

- PR #14: Added UPI fallback for region/cluster_name in write_aws_tfvars
- This PR: Makes platform detection itself UPI-aware