### PR TITLE
WINC-1633: Add PTR record support for BYOH Windows nodes on vSphere and Nutanix

### DIFF
--- a/lib/windows-vm-bootstrap.tf
+++ b/lib/windows-vm-bootstrap.tf
@@ -2,7 +2,7 @@
 # Works across all platforms: AWS, GCP, Azure, vSphere, Nutanix
 
 data "template_file" "windows-userdata" {
-  count    = "${var.winc_number_workers}"
+  count    = var.winc_number_workers
   template = <<EOF
 <powershell>
 # Rename Machine (required for AWS, Azure, Nutanix; optional for GCP)

--- a/nutanix/dns-ptr-records.tf
+++ b/nutanix/dns-ptr-records.tf
@@ -1,0 +1,70 @@
+# WINC-1633: PTR record management for BYOH Windows nodes on Nutanix.
+# MAO creates PTR records for MachineSet VMs automatically, but BYOH nodes
+# need them provisioned explicitly. Without PTR records, WMCO fails with
+# "no such host" errors during reverse DNS lookups.
+#
+# Uses RFC 2136 dynamic DNS updates (BIND, Windows DNS Server, etc.).
+
+terraform {
+  required_providers {
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.4.0"
+    }
+  }
+}
+
+provider "dns" {
+  update {
+    server        = var.dns_server
+    key_name      = var.dns_key_name
+    key_algorithm = var.dns_key_algorithm
+    key_secret    = var.dns_key_secret
+  }
+}
+
+resource "dns_ptr_record" "windows_ptr" {
+  count = var.enable_ptr_records ? var.winc_number_workers : 0
+
+  zone = var.dns_reverse_zone
+
+  # Last two octets of the IP become the PTR record name (assumes /16 reverse zone)
+  name = join(".", slice(
+    reverse(split(".", nutanix_virtual_machine.win_server[count.index].nic_list[0].ip_endpoint_list[0].ip)),
+    0, 2
+  ))
+
+  ptr = "${nutanix_virtual_machine.win_server[count.index].name}.${var.dns_domain}."
+  ttl = 300
+}
+
+resource "null_resource" "validate_ptr_records" {
+  count = var.enable_ptr_records && var.validate_ptr_records ? var.winc_number_workers : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Validating PTR record for ${nutanix_virtual_machine.win_server[count.index].nic_list[0].ip_endpoint_list[0].ip}"
+      sleep 10
+      RESULT=$(nslookup ${nutanix_virtual_machine.win_server[count.index].nic_list[0].ip_endpoint_list[0].ip} ${var.dns_server} 2>&1 | grep "name =")
+      if [ -z "$RESULT" ]; then
+        echo "ERROR: PTR record not found for ${nutanix_virtual_machine.win_server[count.index].nic_list[0].ip_endpoint_list[0].ip}"
+        exit 1
+      else
+        echo "SUCCESS: $RESULT"
+      fi
+    EOT
+  }
+
+  depends_on = [dns_ptr_record.windows_ptr]
+}
+
+output "ptr_records" {
+  description = "PTR records created for BYOH Windows instances"
+  value = var.enable_ptr_records ? [
+    for i in range(var.winc_number_workers) : {
+      ip   = nutanix_virtual_machine.win_server[i].nic_list[0].ip_endpoint_list[0].ip
+      fqdn = "${nutanix_virtual_machine.win_server[i].name}.${var.dns_domain}."
+      ptr  = dns_ptr_record.windows_ptr[i].ptr
+    }
+  ] : []
+}

--- a/nutanix/dns-variables.tf
+++ b/nutanix/dns-variables.tf
@@ -1,0 +1,50 @@
+# DNS variables for PTR record management (WINC-1633)
+
+variable "dns_server" {
+  description = "DNS server address for RFC 2136 updates"
+  type        = string
+  default     = ""
+}
+
+variable "dns_domain" {
+  description = "DNS domain for Windows instance FQDNs (e.g., winc.devcluster.openshift.com)"
+  type        = string
+  default     = ""
+}
+
+variable "dns_reverse_zone" {
+  description = "Reverse DNS zone (e.g., '0.10.in-addr.arpa.' for 10.0.0.0/16)"
+  type        = string
+  default     = ""
+}
+
+variable "dns_key_name" {
+  description = "TSIG key name for RFC 2136 authentication"
+  type        = string
+  default     = "update-key"
+}
+
+variable "dns_key_algorithm" {
+  description = "TSIG key algorithm"
+  type        = string
+  default     = "hmac-sha256"
+}
+
+variable "dns_key_secret" {
+  description = "Base64-encoded TSIG key secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "enable_ptr_records" {
+  description = "Enable PTR record creation for BYOH Windows instances"
+  type        = bool
+  default     = false
+}
+
+variable "validate_ptr_records" {
+  description = "Run nslookup validation after PTR record creation"
+  type        = bool
+  default     = false
+}

--- a/nutanix/main.tf
+++ b/nutanix/main.tf
@@ -5,8 +5,12 @@ terraform {
       version = "~> 1.8.0"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
       version = "~> 2.2.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.7.0"
     }
   }
 }
@@ -25,13 +29,13 @@ data "nutanix_image" "windows" {
 }
 
 resource "nutanix_virtual_machine" "win_server" {
-  count                = var.winc_number_workers
-  name                = "${var.winc_instance_name}-${count.index}"
-  cluster_uuid        = var.winc_cluster_uuid
-  
+  count        = var.winc_number_workers
+  name         = "${var.winc_instance_name}-${count.index}"
+  cluster_uuid = var.winc_cluster_uuid
+
   num_vcpus_per_socket = 2
-  num_sockets         = 1
-  memory_size_mib     = 8192
+  num_sockets          = 1
+  memory_size_mib      = 8192
 
   guest_customization_cloud_init_user_data = base64encode(data.template_file.windows-userdata[count.index].rendered)
 

--- a/vsphere/dns-ptr-records.tf
+++ b/vsphere/dns-ptr-records.tf
@@ -1,0 +1,64 @@
+# WINC-1633: PTR record management for BYOH Windows nodes on vSphere.
+# MAO creates PTR records for MachineSet VMs automatically, but BYOH nodes
+# need them provisioned explicitly. Without PTR records, WMCO fails with
+# "no such host" errors during reverse DNS lookups.
+#
+# Uses RFC 2136 dynamic DNS updates (BIND, Windows DNS Server, etc.).
+
+provider "dns" {
+  dynamic "update" {
+    for_each = var.enable_ptr_records ? [1] : []
+    content {
+      server        = var.dns_server
+      key_name      = var.dns_key_name
+      key_algorithm = var.dns_key_algorithm
+      key_secret    = var.dns_key_secret
+    }
+  }
+}
+
+resource "dns_ptr_record" "windows_ptr" {
+  count = var.enable_ptr_records ? var.winc_number_workers : 0
+
+  zone = var.dns_reverse_zone
+
+  # Last two octets of the IP become the PTR record name (assumes /16 reverse zone)
+  name = join(".", slice(
+    reverse(split(".", vsphere_virtual_machine.win_server[count.index].default_ip_address)),
+    0, 2
+  ))
+
+  ptr = "${vsphere_virtual_machine.win_server[count.index].name}.${var.dns_domain}."
+  ttl = 300
+}
+
+resource "null_resource" "validate_ptr_records" {
+  count = var.enable_ptr_records && var.validate_ptr_records ? var.winc_number_workers : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Validating PTR record for ${vsphere_virtual_machine.win_server[count.index].default_ip_address}"
+      sleep 10
+      RESULT=$(nslookup ${vsphere_virtual_machine.win_server[count.index].default_ip_address} ${var.dns_server} 2>&1 | grep "name =")
+      if [ -z "$RESULT" ]; then
+        echo "ERROR: PTR record not found for ${vsphere_virtual_machine.win_server[count.index].default_ip_address}"
+        exit 1
+      else
+        echo "SUCCESS: $RESULT"
+      fi
+    EOT
+  }
+
+  depends_on = [dns_ptr_record.windows_ptr]
+}
+
+output "ptr_records" {
+  description = "PTR records created for BYOH Windows instances"
+  value = var.enable_ptr_records ? [
+    for i in range(var.winc_number_workers) : {
+      ip   = vsphere_virtual_machine.win_server[i].default_ip_address
+      fqdn = "${vsphere_virtual_machine.win_server[i].name}.${var.dns_domain}."
+      ptr  = dns_ptr_record.windows_ptr[i].ptr
+    }
+  ] : []
+}

--- a/vsphere/dns-variables.tf
+++ b/vsphere/dns-variables.tf
@@ -1,0 +1,50 @@
+# DNS variables for PTR record management (WINC-1633)
+
+variable "dns_server" {
+  description = "DNS server address for RFC 2136 updates"
+  type        = string
+  default     = ""
+}
+
+variable "dns_domain" {
+  description = "DNS domain for Windows instance FQDNs (e.g., winc.devcluster.openshift.com)"
+  type        = string
+  default     = ""
+}
+
+variable "dns_reverse_zone" {
+  description = "Reverse DNS zone (e.g., '0.10.in-addr.arpa.' for 10.0.0.0/16)"
+  type        = string
+  default     = ""
+}
+
+variable "dns_key_name" {
+  description = "TSIG key name for RFC 2136 authentication"
+  type        = string
+  default     = "update-key"
+}
+
+variable "dns_key_algorithm" {
+  description = "TSIG key algorithm"
+  type        = string
+  default     = "hmac-sha256"
+}
+
+variable "dns_key_secret" {
+  description = "Base64-encoded TSIG key secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "enable_ptr_records" {
+  description = "Enable PTR record creation for BYOH Windows instances"
+  type        = bool
+  default     = false
+}
+
+variable "validate_ptr_records" {
+  description = "Run nslookup validation after PTR record creation"
+  type        = bool
+  default     = false
+}

--- a/vsphere/main.tf
+++ b/vsphere/main.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/time"
       version = "~> 0.7.0"
     }
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.4.0"
+    }
   }
 }
 
@@ -43,15 +47,15 @@ data "vsphere_virtual_machine" "template" {
 }
 
 resource "vsphere_virtual_machine" "win_server" {
-  count             = var.winc_number_workers
-  name              = "${var.winc_instance_name}-${count.index}"
-  resource_pool_id  = data.vsphere_resource_pool.pool.id
-  datastore_id      = data.vsphere_datastore.datastore.id
-  num_cpus          = data.vsphere_virtual_machine.template.num_cpus
-  memory            = data.vsphere_virtual_machine.template.memory
-  guest_id          = data.vsphere_virtual_machine.template.guest_id
-  scsi_type         = data.vsphere_virtual_machine.template.scsi_type
-  
+  count            = var.winc_number_workers
+  name             = "${var.winc_instance_name}-${count.index}"
+  resource_pool_id = data.vsphere_resource_pool.pool.id
+  datastore_id     = data.vsphere_datastore.datastore.id
+  num_cpus         = data.vsphere_virtual_machine.template.num_cpus
+  memory           = data.vsphere_virtual_machine.template.memory
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
+
   network_interface {
     network_id   = data.vsphere_network.network.id
     adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
@@ -89,12 +93,12 @@ resource "vsphere_virtual_machine" "win_server" {
 
 
 resource "time_sleep" "wait_120_seconds" {
-  depends_on = [vsphere_virtual_machine.win_server]
+  depends_on      = [vsphere_virtual_machine.win_server]
   create_duration = "120s"
 }
 
 output "instance_ip" {
-  value = vsphere_virtual_machine.win_server[*].default_ip_address
+  value      = vsphere_virtual_machine.win_server[*].default_ip_address
   depends_on = [time_sleep.wait_120_seconds]
 }
 

--- a/vsphere/variables.tf
+++ b/vsphere/variables.tf
@@ -1,85 +1,85 @@
 # Instance name for the newly created Windows VM
-variable winc_instance_name {
-    type        = string
-    description = "Base name for Windows instances (will have -<index> suffix appended)"
+variable "winc_instance_name" {
+  type        = string
+  description = "Base name for Windows instances (will have -<index> suffix appended)"
 
-    validation {
-        condition     = length(var.winc_instance_name) <= 8
-        error_message = "Instance name must be 8 characters or less (Windows NetBIOS limit: 15 chars including '-<index>' suffix)."
-    }
+  validation {
+    condition     = length(var.winc_instance_name) <= 8
+    error_message = "Instance name must be 8 characters or less (Windows NetBIOS limit: 15 chars including '-<index>' suffix)."
+  }
 }
 
 # Hostname for one of the already existing cluster worker VM nodes
-variable winc_machine_hostname {
-    type = string
+variable "winc_machine_hostname" {
+  type = string
 }
 
 # vSphere template name
-variable winc_vsphere_template {
-    type = string
+variable "winc_vsphere_template" {
+  type = string
 }
 
 # vSphere datacenter
-variable winc_datacenter {
-    type = string
+variable "winc_datacenter" {
+  type = string
 }
 
 # vSphere datastore
-variable winc_datastore {
-    type = string
+variable "winc_datastore" {
+  type = string
 }
 
 # vSphere network
-variable winc_network {
-    type = string
+variable "winc_network" {
+  type = string
 }
 
 # vSphere resource pool
-variable winc_resource_pool {
-    type = string
+variable "winc_resource_pool" {
+  type = string
 }
 
 # Number of BYOH worker instances
-variable winc_number_workers {
-    type = number
-    default = 2
+variable "winc_number_workers" {
+  type    = number
+  default = 2
 }
 
 # vSphere authentication variables
-variable vsphere_user {
-    type        = string
-    description = "vSphere username"
+variable "vsphere_user" {
+  type        = string
+  description = "vSphere username"
 }
 
-variable vsphere_password {
-    type        = string
-    description = "vSphere password"
-    sensitive   = true
+variable "vsphere_password" {
+  type        = string
+  description = "vSphere password"
+  sensitive   = true
 }
 
-variable vsphere_server {
-    type        = string
-    description = "vSphere server hostname"
+variable "vsphere_server" {
+  type        = string
+  description = "vSphere server hostname"
 }
 
 # Windows administrator username
-variable admin_username {
-    type        = string
-    default     = "Administrator"
-    description = "Administrator username for Windows instances"
+variable "admin_username" {
+  type        = string
+  default     = "Administrator"
+  description = "Administrator username for Windows instances"
 }
 
 # Windows administrator password
-variable admin_password {
-    type        = string
-    sensitive   = true
-    description = "Administrator password for Windows instances"
+variable "admin_password" {
+  type        = string
+  sensitive   = true
+  description = "Administrator password for Windows instances"
 }
 
 # SSH public key for remote access
-variable ssh_public_key {
-    type        = string
-    description = "SSH public key for remote access to Windows instances"
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key for remote access to Windows instances"
 }
 
 # Networking Configuration


### PR DESCRIPTION
## Summary
- Adds Terraform-managed PTR (reverse DNS) records for BYOH Windows nodes on vSphere and Nutanix using RFC 2136 dynamic DNS updates
- Gated by enable_ptr_records variable (opt-in, defaults to false) so existing deployments are unaffected
- Fixes WMCO 'no such host' DNS resolution failures that break BYOH tests (OCP-42496, OCP-42516, OCP-42484)

## Changes
### New files
- vsphere/dns-ptr-records.tf + vsphere/dns-variables.tf - PTR record resources for vSphere
- nutanix/dns-ptr-records.tf + nutanix/dns-variables.tf - PTR record resources for Nutanix

### Modified files
- nutanix/main.tf - Added missing hashicorp/time provider declaration
- vsphere/main.tf, vsphere/variables.tf, lib/windows-vm-bootstrap.tf - terraform fmt fixes

## Test plan
- [ ] terraform fmt -check passes for both vsphere/ and nutanix/
- [ ] terraform plan succeeds with enable_ptr_records = false (no DNS changes)
- [ ] terraform plan succeeds with enable_ptr_records = true (PTR records planned)
- [ ] terraform apply creates PTR records and nslookup resolves to FQDN
- [ ] terraform destroy cleans up PTR records
- [ ] BYOH tests OCP-42496, OCP-42516 pass on vSphere/Nutanix

Fixes: https://issues.redhat.com/browse/WINC-1633
