### PR TITLE
Fix UPI detection to support Azure IPI Windows BYOH provisioning

### DIFF
--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -15,10 +15,12 @@ function get_platform() {
     fi
 
     # Auto-detect UPI clusters: If no Machine API, use "none" platform
-    # UPI clusters (any platform) don't have Machine API machines
+    # UPI clusters don't have MachineSets (Machine API not supported)
+    # IPI clusters always have MachineSets (created by installer)
+    # Check for MachineSets instead of Machines (Machines might not exist yet during provisioning)
     # The "none" platform is designed for manual/BYOH provisioning without data source queries
-    if ! oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=worker --no-headers 2>/dev/null | grep -q .; then
-        log "UPI cluster detected (no Machine API), using platform=none for BYOH provisioning"
+    if ! oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null | grep -q .; then
+        log "UPI cluster detected (no MachineSets in Machine API), using platform=none for BYOH provisioning"
         platform="none"
     fi
 


### PR DESCRIPTION
## Problem

Azure IPI Windows workflows are failing with:
```
Error: error configuring Terraform AWS Provider: no valid credential sources
Platform 'none' - AWS credentials will be auto-discovered by Terraform
```

**Root Cause:**
The UPI auto-detection logic in `get_platform()` checks for worker `Machines` to differentiate IPI vs UPI clusters. However, on Azure IPI clusters:
- The `windows-byoh-provision` step runs before MachineSets scale up Windows machines
- Machine objects don't exist yet during provisioning
- The check incorrectly detects this as a UPI cluster
- Platform is set to `"none"` which uses AWS Terraform configuration
- Azure credentials are ignored, causing AWS provider errors

## Solution

**Check for `MachineSets` instead of `Machines`:**
- **IPI clusters:** MachineSets are created by the installer (always present from the start)
- **UPI clusters:** No MachineSets exist (Machine API not supported)
- MachineSets are a more reliable indicator of IPI vs UPI deployment type

## Changes

**File:** `lib/platform.sh`
```diff
- if ! oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=worker --no-headers 2>/dev/null | grep -q .; then
+ if ! oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null | grep -q .; then
```

## Impact

**Before fix:**
- ❌ Azure IPI: Incorrectly detected as UPI → platform=none → AWS Terraform config → **FAIL**
- ✅ AWS UPI: Correctly detected as UPI → platform=none → AWS Terraform config → works

**After fix:**
- ✅ Azure IPI: Correctly detected as IPI → platform=azure → Azure Terraform config → **works**
- ✅ AWS UPI: Correctly detected as UPI → platform=none → AWS Terraform config → works

## Testing

Verified on:
- **Azure IPI:** Windows BYOH provisioning now uses correct Azure Terraform provider
- **AWS UPI:** Windows BYOH provisioning continues to work with platform=none

## Related

- **Release repo PR:** Will update once this merges to trigger image rebuild
- **CI Image:** `registry.ci.openshift.org/ci/terraform-windows-provisioner:latest` will automatically rebuild from main
- **Affected workflows:**
  - `cucushift-installer-rehearse-azure-ipi-ovn-winc` (currently failing)
  - `cucushift-installer-rehearse-vsphere-ipi-ovn-winc` (potentially affected)

/cc @jianlinliu