### PR TITLE
Add debug logging to UPI detection to diagnose vSphere IPI misdetection

### DIFF
--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -19,9 +19,33 @@ function get_platform() {
     # IPI clusters always have MachineSets (created by installer)
     # Check for MachineSets instead of Machines (Machines might not exist yet during provisioning)
     # The "none" platform is designed for manual/BYOH provisioning without data source queries
-    if ! oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null | grep -q .; then
+
+    # Debug: Check MachineSets with full error output
+    log "Checking for MachineSets to detect IPI vs UPI cluster..."
+    local machineset_output
+    local machineset_error
+    local machineset_exit_code
+
+    machineset_output=$(oc get machinesets -n openshift-machine-api --no-headers 2>&1)
+    machineset_exit_code=$?
+
+    log "DEBUG: oc get machinesets exit code: ${machineset_exit_code}"
+    log "DEBUG: oc get machinesets output: '${machineset_output}'"
+
+    # Check if command failed or output is empty
+    if [[ ${machineset_exit_code} -ne 0 ]]; then
+        log "DEBUG: oc get machinesets failed with exit code ${machineset_exit_code}"
+        log "DEBUG: Error: ${machineset_output}"
+        log "UPI cluster detected (MachineSets query failed - Machine API not available), using platform=none for BYOH provisioning"
+        platform="none"
+    elif [[ -z "${machineset_output}" ]] || ! echo "${machineset_output}" | grep -q .; then
+        log "DEBUG: oc get machinesets succeeded but returned empty output"
         log "UPI cluster detected (no MachineSets in Machine API), using platform=none for BYOH provisioning"
         platform="none"
+    else
+        local machineset_count=$(echo "${machineset_output}" | wc -l)
+        log "DEBUG: Found ${machineset_count} MachineSets - IPI cluster detected"
+        log "IPI cluster detected with ${machineset_count} MachineSets, using platform=${platform}"
     fi
 
     if [[ ! " ${SUPPORTED_PLATFORMS[@]} " =~ " ${platform} " ]]; then


### PR DESCRIPTION
## Problem

vSphere IPI clusters are being **incorrectly detected as UPI clusters** even though MachineSets exist.

**Evidence from Prow logs:**
- Prow step wrapper: Finds **2 MachineSets** ✓
- byoh.sh (moments later): Finds **0 MachineSets** ✗
- Result: vSphere IPI uses AWS Terraform config → **FAILS**

Example job: https://github.com/openshift/release/pull/76816

## Root Cause

The current code silently swallows errors with `2>/dev/null`, making it impossible to diagnose:
```bash
if ! oc get machinesets -n openshift-machine-api --no-headers 2>/dev/null | grep -q .; then
    # Silent failure - can't see WHY it failed
```

## Changes

### Added Comprehensive Debug Logging

```bash
machineset_output=$(oc get machinesets -n openshift-machine-api --no-headers 2>&1)
machineset_exit_code=$?

log "DEBUG: oc get machinesets exit code: ${machineset_exit_code}"
log "DEBUG: oc get machinesets output: '${machineset_output}'"
```

### Three Detection Paths

1. **Command fails (exit != 0):** RBAC/permissions issue → UPI
2. **Command succeeds, empty output:** True UPI cluster → UPI
3. **Command succeeds, has output:** IPI cluster → Use detected platform

### Debug Output Examples

**IPI cluster (expected):**
```
DEBUG: oc get machinesets exit code: 0
DEBUG: oc get machinesets output: 'winworker   2   2   ...'
DEBUG: Found 2 MachineSets - IPI cluster detected
IPI cluster detected with 2 MachineSets, using platform=vsphere
```

**UPI cluster (true UPI):**
```
DEBUG: oc get machinesets exit code: 0
DEBUG: oc get machinesets output: ''
UPI cluster detected (no MachineSets in Machine API), using platform=none
```

**Permission denied (what we suspect):**
```
DEBUG: oc get machinesets exit code: 1
DEBUG: oc get machinesets output: 'Error from server (Forbidden): ...'
UPI cluster detected (MachineSets query failed - Machine API not available), using platform=none
```

## What This Will Reveal

1. **RBAC issue:** Container ServiceAccount lacks `machinesets.list` permission
2. **Race condition:** MachineSets deleted between checks (unlikely)
3. **Kubeconfig issue:** Different context/namespace
4. **Something else:** Full error will be visible

## Testing

Deploy to vSphere IPI cluster and check Prow logs for DEBUG output.

## Related

- PR #17: Original UPI detection fix (merged, but still failing)
- Release PR #76816: vSphere BYOH jobs (currently failing due to this issue)