### PR TITLE
WINC-1835: Add node pool integration for BYOH Prow CI

### DIFF
--- a/BYOH_PROW_INTEGRATION.md
+++ b/BYOH_PROW_INTEGRATION.md
@@ -1,0 +1,219 @@
+# BYOH Node Pool Integration for Prow CI
+
+## Problem Statement
+
+WC-BYOH tests in `openshift-tests-private` were originally designed to work with ephemeral MachineSets created during test execution. When attempting to use persistent terraform-provisioned BYOH nodes in Prow CI, we encountered architectural incompatibilities:
+
+### What Breaks With Direct ConfigMap Approach
+
+**Current approach** (creates `windows-instances` ConfigMap):
+1. Terraform provisions 2 persistent Windows VMs (byoh-0, byoh-1)
+2. Creates `windows-instances` ConfigMap with both nodes
+3. WMCO configures both nodes
+4. Test runs and **deletes the entire ConfigMap** during cleanup
+5. WMCO deconfigures **ALL BYOH nodes** on the cluster
+6. Next test starts but nodes still reconfiguring → **FAIL**
+
+**Result**: Cascade failures, flaky tests, regression from stable state.
+
+## Solution: Node Pool Integration
+
+The `openshift-tests-private` repository already has a **node pool system** (since ~2024) that allows tests to:
+- Allocate ONE node at a time from a shared pool
+- Use the node for testing
+- Release it back to the pool when done
+- **Never delete the ConfigMap globally**
+
+### How It Works
+
+**New approach** (creates `windows-node-pool` ConfigMap):
+1. Terraform provisions 2 persistent Windows VMs
+2. Creates `windows-node-pool` ConfigMap with both nodes marked `available`
+3. Test 1 allocates byoh-0 from pool → creates temporary `windows-instances` with only byoh-0
+4. Test 1 completes → releases byoh-0 back to pool
+5. Test 2 allocates byoh-1 from pool → creates temporary `windows-instances` with only byoh-1
+6. Tests never interfere with each other ✅
+
+## Implementation
+
+### Node Pool ConfigMap Format
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: windows-node-pool
+  namespace: openshift-windows-machine-config-operator
+data:
+  192.168.221.179: |
+    status: available
+    username: Administrator
+    address-type: ip
+    platform: vsphere
+    test-id:
+    allocated-at:
+    last-updated: 2026-03-31T12:00:00Z
+  192.168.221.181: |
+    status: available
+    username: Administrator
+    address-type: ip
+    platform: vsphere
+    test-id:
+    allocated-at:
+    last-updated: 2026-03-31T12:00:00Z
+```
+
+### Usage
+
+#### Create Node Pool (instead of windows-instances)
+
+```bash
+# Set environment variable to use node pool mode
+export USE_NODE_POOL=true
+
+# Provision nodes and create node pool ConfigMap
+./byoh.sh apply
+
+# Or create/update just the node pool ConfigMap
+./byoh.sh configmap
+```
+
+#### Destroy Nodes and Clean Pool
+
+```bash
+# Removes nodes from pool and destroys VMs
+export USE_NODE_POOL=true
+./byoh.sh destroy
+```
+
+### Test Integration
+
+No changes needed in `openshift-tests-private`! The existing `setBYOH()` function already:
+
+1. Checks if node pool exists: `isNodePoolEnabled(oc)`
+2. Allocates one node: `allocateNodeFromPool(oc, testID, platform, addressType)`
+3. Creates temporary `windows-instances` ConfigMap with ONLY that node
+4. Waits for node to be Ready
+5. Test runs
+6. Cleanup releases node: `releaseNodeToPool(oc, nodeAddress, false)`
+
+**File**: `test/extended/winc/utils.go`, lines 1307-1391
+
+## Prow Integration
+
+### Step 1: Update Prow Job Definition
+
+In `ci-operator/config/openshift/release/openshift-release-master-*.yaml`:
+
+```yaml
+- as: windows-byoh-provision
+  commands: |
+    # Enable node pool mode for test isolation
+    export USE_NODE_POOL=true
+
+    # Rest of provisioning logic...
+    ./byoh.sh apply
+  ...
+```
+
+### Step 2: Update Cleanup Step
+
+```yaml
+- as: windows-byoh-cleanup
+  commands: |
+    export USE_NODE_POOL=true
+    ./byoh.sh destroy
+  ...
+```
+
+### No Changes Needed To:
+- Test code in `openshift-tests-private`
+- WMCO configuration
+- Node provisioning logic (just ConfigMap format changes)
+
+## Benefits
+
+✅ **Test Isolation**: Each test gets its own node, can't interfere with others
+✅ **No Global Deconfiguration**: Node pool preserves all nodes
+✅ **Faster Tests**: Nodes stay configured, just reallocate between tests
+✅ **Existing Code**: Uses production node pool system already in use
+✅ **Clean Architecture**: Tests work identically in Jenkins (MachineSets) and Prow (node pool)
+
+## Migration Path
+
+### Phase 1: Terraform-Windows-Provisioner (This PR)
+- ✅ Add `create_node_pool_configmap()` function
+- ✅ Add `delete_node_pool_configmap()` function
+- ✅ Add `USE_NODE_POOL` environment variable support
+- ✅ Update `byoh.sh` to support both modes
+
+### Phase 2: Release Repository
+- Update Prow job definitions to set `USE_NODE_POOL=true`
+- Test on vSphere and Azure platforms
+- Monitor for regressions
+
+### Phase 3: Validation
+- Run full WC-BYOH test suite with node pool
+- Verify all 5 tests pass consistently
+- Compare timing vs MachineSet approach
+
+## Backwards Compatibility
+
+The default behavior remains unchanged (creates `windows-instances` ConfigMap). Node pool mode is opt-in via `USE_NODE_POOL=true`. This allows gradual migration and easy rollback if issues are discovered.
+
+## Related Issues
+
+- **WINC-1835**: Node pool integration for terraform-provisioned nodes
+- **WINC-1837**: Original attempt at direct terraform detection (closed due to architectural issues)
+- **PR #29631**: Closed PR that attempted to bypass node pool (caused regression)
+
+## Testing
+
+### Local Testing
+
+```bash
+# 1. Provision with node pool
+export USE_NODE_POOL=true
+./byoh.sh apply
+
+# 2. Verify node pool created
+oc get configmap windows-node-pool -n openshift-windows-machine-config-operator -o yaml
+
+# 3. Run one BYOH test to verify allocation works
+oc get configmap windows-instances -n openshift-windows-machine-config-operator
+# Should show ONLY the allocated node
+
+# 4. After test completes, verify node released
+oc get configmap windows-node-pool -n openshift-windows-machine-config-operator -o yaml
+# Should show node back to "available" status
+
+# 5. Clean up
+./byoh.sh destroy
+```
+
+### Expected Behavior
+
+**Before test:**
+- `windows-node-pool` exists with 2 available nodes
+- `windows-instances` does NOT exist
+
+**During test:**
+- `windows-node-pool` shows 1 in-use, 1 available
+- `windows-instances` exists with ONLY the in-use node
+
+**After test:**
+- `windows-node-pool` shows 2 available nodes again
+- `windows-instances` deleted by test cleanup
+
+## Future Enhancements
+
+1. **Pool Statistics**: Add pool-available, pool-in-use counters to ConfigMap metadata
+2. **Health Checks**: Automatically mark nodes unavailable if NotReady
+3. **Lease Timeouts**: Auto-release nodes if test hangs
+4. **Multi-Platform**: Support mixed pools (vSphere + Azure nodes)
+
+## References
+
+- Node pool implementation: `openshift-tests-private/test/extended/winc/utils.go:2697-3263`
+- Test usage: `openshift-tests-private/test/extended/winc/winc.go` (setBYOH calls)
+- Architecture discussion: PR #29631 closing comment

--- a/byoh.sh
+++ b/byoh.sh
@@ -19,6 +19,7 @@ source "${SCRIPT_DIR}/lib/credentials.sh"
 source "${SCRIPT_DIR}/lib/platform.sh"
 source "${SCRIPT_DIR}/lib/validation.sh"
 source "${SCRIPT_DIR}/lib/terraform.sh"
+source "${SCRIPT_DIR}/lib/terraform-node-pool.sh"
 
 # Helper functions
 function log() {
@@ -98,6 +99,9 @@ Configuration:
     - WINDOWS_ADMIN_USERNAME: Windows username (default: Administrator)
     - AZURE_VM_EXTENSION_HANDLER_VERSION: Azure VM extension version
     - ENVIRONMENT_TAG: Environment tag for resources
+    - USE_NODE_POOL: Use node pool ConfigMap for test isolation (default: false)
+                      Set to 'true' for Prow CI integration with openshift-tests
+    - SKIP_CONFIGMAP_CREATION: Skip ConfigMap creation during apply (default: false)
 
     To create a user config file:
         mkdir -p ~/.config/byoh-provisioner
@@ -220,9 +224,16 @@ function main() {
 
             # Create ConfigMap unless explicitly skipped
             if [[ "$(get_config 'SKIP_CONFIGMAP_CREATION' 'false')" != "true" ]]; then
-                create_configmap "$templates_dir" "$platform"
-                log "Provisioning completed successfully!"
-                log "Windows instances are ready and registered with WMCO"
+                # Check if node pool mode is enabled
+                if [[ "$(get_config 'USE_NODE_POOL' 'false')" == "true" ]]; then
+                    create_node_pool_configmap "$templates_dir" "$platform"
+                    log "Provisioning completed successfully!"
+                    log "Windows nodes added to node pool for test allocation"
+                else
+                    create_configmap "$templates_dir" "$platform"
+                    log "Provisioning completed successfully!"
+                    log "Windows instances are ready and registered with WMCO"
+                fi
             else
                 log "Provisioning completed successfully!"
                 log "ConfigMap creation skipped (SKIP_CONFIGMAP_CREATION=true)"
@@ -251,7 +262,13 @@ function main() {
                     ;;
             esac
 
-            delete_configmap "$templates_dir"
+            # Remove nodes from appropriate ConfigMap before destroying VMs
+            if [[ "$(get_config 'USE_NODE_POOL' 'false')" == "true" ]]; then
+                delete_node_pool_configmap "$templates_dir"
+            else
+                delete_configmap "$templates_dir"
+            fi
+
             terraform_destroy "$templates_dir"
             cleanup_templates_dir "$templates_dir"
             log "Destruction completed successfully!"
@@ -262,8 +279,15 @@ function main() {
             if [[ ! -d "$templates_dir" ]]; then
                 error "Directory ${templates_dir} not found. Did you run ./byoh.sh apply first?"
             fi
-            create_configmap "$templates_dir" "$platform"
-            log "ConfigMap created/updated successfully!"
+
+            # Check if node pool mode is enabled
+            if [[ "$(get_config 'USE_NODE_POOL' 'false')" == "true" ]]; then
+                create_node_pool_configmap "$templates_dir" "$platform"
+                log "Node pool ConfigMap created/updated successfully!"
+            else
+                create_configmap "$templates_dir" "$platform"
+                log "ConfigMap created/updated successfully!"
+            fi
             ;;
 
         "arguments")

--- a/lib/terraform-node-pool.sh
+++ b/lib/terraform-node-pool.sh
@@ -1,0 +1,191 @@
+# Create node pool ConfigMap for test isolation
+# This allows tests to allocate nodes individually instead of using all nodes at once
+function create_node_pool_configmap() {
+    local templates_dir="$1"
+    local platform="$2"
+
+    log "Creating node pool ConfigMap for Windows instances..."
+
+    local wmco_namespace
+    wmco_namespace=$(get_wmco_namespace)
+
+    if [[ -z "$wmco_namespace" ]]; then
+        error "Failed to get WMCO namespace. Is the Windows Machine Config Operator installed?"
+    fi
+
+    log "Using WMCO namespace: $wmco_namespace"
+
+    local config_file="${templates_dir}/byoh_node_pool_cm.yaml"
+
+    # Change to templates directory to run terraform output
+    cd "$templates_dir" || error "Failed to change to templates directory: ${templates_dir}"
+
+    # Determine identifier type (IP or DNS/hostname) from configuration
+    local identifier_type
+    identifier_type=$(get_config "WMCO_IDENTIFIER_TYPE" "ip")
+
+    log "Node pool identifier type: $identifier_type"
+
+    local terraform_cmd="${TERRAFORM_BIN:-terraform}"
+    local identifiers=""
+
+    # Get identifiers based on configured type
+    if [[ "$identifier_type" == "dns" ]]; then
+        # Try to get DNS hostnames from Terraform output
+        identifiers=$($terraform_cmd output -json instance_hostname 2>/dev/null | jq -r '.[]' 2>/dev/null)
+
+        if [[ -z "$identifiers" ]]; then
+            log "Warning: instance_hostname output not available in Terraform, falling back to IP addresses"
+            identifier_type="ip"
+            identifiers=$($terraform_cmd output -json instance_ip 2>/dev/null | jq -r '.[]')
+        fi
+    else
+        # Default to IP addresses
+        identifiers=$($terraform_cmd output -json instance_ip 2>/dev/null | jq -r '.[]')
+    fi
+
+    if [[ -z "$identifiers" ]]; then
+        error "Failed to get instance identifiers from Terraform output"
+    fi
+
+    local username=$(get_user_name "$platform")
+    local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    log "Creating node pool entries for identifiers: $(echo $identifiers | tr '\n' ' ')"
+
+    # Create ConfigMap YAML header
+    cat > "$config_file" << EOF
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: windows-node-pool
+  namespace: ${wmco_namespace}
+data:
+EOF
+
+    # Add each node to the pool with available status
+    for identifier in $identifiers; do
+        # Remove quotes if present
+        identifier="${identifier%\"}"
+        identifier="${identifier#\"}"
+
+        # Node pool entry format
+        cat >> "$config_file" << EOF
+  ${identifier}: |
+    status: available
+    username: ${username}
+    address-type: ${identifier_type}
+    platform: ${platform}
+    test-id:
+    allocated-at:
+    last-updated: ${timestamp}
+EOF
+    done
+
+    log "Node pool ConfigMap file created: ${config_file}"
+
+    # Apply or patch ConfigMap
+    if oc get configmap windows-node-pool -n "$wmco_namespace" &>/dev/null; then
+        log "Node pool ConfigMap already exists, patching with new entries..."
+
+        # Extract and update each entry
+        for identifier in $identifiers; do
+            identifier="${identifier%\"}"
+            identifier="${identifier#\"}"
+
+            # Check if entry already exists
+            local existing_status
+            existing_status=$(oc get configmap windows-node-pool -n "$wmco_namespace" -o jsonpath="{.data['${identifier}']}" 2>/dev/null | grep "^status:" | awk '{print $2}')
+
+            # Only add if not already in pool, or if status is unavailable
+            if [[ -z "$existing_status" ]] || [[ "$existing_status" == "unavailable" ]]; then
+                log "Adding/updating node pool entry: ${identifier}"
+
+                # Use strategic merge patch to add/update entry
+                local entry_data="status: available
+username: ${username}
+address-type: ${identifier_type}
+platform: ${platform}
+test-id:
+allocated-at:
+last-updated: ${timestamp}"
+
+                oc patch configmap windows-node-pool -n "$wmco_namespace" \
+                    --type merge \
+                    -p "{\"data\":{\"${identifier}\":\"${entry_data}\"}}" \
+                    || error "Failed to patch node pool ConfigMap for ${identifier}"
+            else
+                log "Node ${identifier} already in pool with status: ${existing_status}"
+            fi
+        done
+
+        log "Node pool ConfigMap updated successfully"
+    else
+        log "Node pool ConfigMap does not exist, creating new one..."
+        oc create -f "$config_file" || error "Failed to create node pool ConfigMap"
+        log "Node pool ConfigMap created successfully"
+    fi
+
+    log "Node pool ready with $(echo $identifiers | wc -w) nodes"
+}
+
+# Delete node pool ConfigMap
+function delete_node_pool_configmap() {
+    local templates_dir="$1"
+
+    log "Removing nodes from node pool ConfigMap..."
+
+    local wmco_namespace
+    wmco_namespace=$(get_wmco_namespace)
+
+    if [[ -z "$wmco_namespace" ]]; then
+        log "Warning: Failed to get WMCO namespace, skipping node pool cleanup"
+        return 0
+    fi
+
+    # Check if node pool exists
+    if ! oc get configmap windows-node-pool -n "$wmco_namespace" &>/dev/null; then
+        log "Node pool ConfigMap does not exist, nothing to clean"
+        return 0
+    fi
+
+    # Change to templates directory to run terraform output
+    cd "$templates_dir" || error "Failed to change to templates directory: ${templates_dir}"
+
+    local terraform_cmd="${TERRAFORM_BIN:-terraform}"
+    local identifiers=""
+
+    # Try to get identifiers from Terraform output (may fail if already destroyed)
+    local identifier_type
+    identifier_type=$(get_config "WMCO_IDENTIFIER_TYPE" "ip")
+
+    if [[ "$identifier_type" == "dns" ]]; then
+        identifiers=$($terraform_cmd output -json instance_hostname 2>/dev/null | jq -r '.[]' 2>/dev/null)
+    fi
+
+    if [[ -z "$identifiers" ]]; then
+        identifiers=$($terraform_cmd output -json instance_ip 2>/dev/null | jq -r '.[]' 2>/dev/null)
+    fi
+
+    if [[ -z "$identifiers" ]]; then
+        log "Warning: Could not get identifiers from Terraform, node pool entries will remain"
+        log "You may need to manually clean the node pool ConfigMap"
+        return 0
+    fi
+
+    # Remove each node from the pool
+    for identifier in $identifiers; do
+        identifier="${identifier%\"}"
+        identifier="${identifier#\"}"
+
+        log "Removing ${identifier} from node pool"
+
+        # Use JSON patch to remove the entry
+        oc patch configmap windows-node-pool -n "$wmco_namespace" \
+            --type=json \
+            -p="[{\"op\": \"remove\", \"path\": \"/data/${identifier}\"}]" \
+            2>/dev/null || log "Warning: Failed to remove ${identifier} from node pool (may not exist)"
+    done
+
+    log "Nodes removed from pool successfully"
+}


### PR DESCRIPTION
## Problem

WC-BYOH tests in openshift-tests-private were originally designed for ephemeral MachineSets. When using persistent terraform-provisioned nodes in Prow CI, we hit architectural incompatibilities:

**Direct ConfigMap approach (PR openshift/openshift-tests-private#29631 - closed)**:
- Creates windows-instances ConfigMap with all nodes
- Tests delete ConfigMap during cleanup
- WMCO deconfigures ALL BYOH nodes on cluster
- Next test starts with unstable nodes - cascade failures

**Result**: Regression from stable to flaky tests

## Solution: Node Pool Integration

The openshift-tests-private repository already has a node pool system that allows:
- Tests to allocate ONE node at a time
- Use the node, then release back to pool
- Never delete ConfigMap globally
- Perfect isolation between tests

## Implementation

### New Files
- lib/terraform-node-pool.sh: Functions to create/delete node pool ConfigMap
- BYOH_PROW_INTEGRATION.md: Comprehensive documentation

### Modified Files
- byoh.sh: Add USE_NODE_POOL environment variable support

### Node Pool ConfigMap Format

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: windows-node-pool
  namespace: openshift-windows-machine-config-operator
data:
  192.168.221.179: |
    status: available
    username: Administrator
    address-type: ip
    platform: vsphere
    test-id:
    allocated-at:
    last-updated: 2026-03-31T12:00:00Z
```

## Usage

### Enable Node Pool Mode
```bash
export USE_NODE_POOL=true
./byoh.sh apply        # Creates node pool ConfigMap
./byoh.sh destroy      # Removes nodes from pool
```

### Prow Integration
In ci-operator/config/.../openshift-release-master-*.yaml:
```yaml
- as: windows-byoh-provision
  commands: |
    export USE_NODE_POOL=true
    ./byoh.sh apply
```

### Test Behavior (No Changes Needed!)
openshift-tests already has node pool support:
1. setBYOH() checks if pool exists
2. Allocates one node from pool
3. Creates temporary windows-instances with ONLY that node
4. Test runs
5. Cleanup releases node back to pool

**File**: test/extended/winc/utils.go:1307-1391

## Benefits

- Test Isolation: Each test gets its own node, cannot interfere
- No Global Deconfiguration: Pool preserves all nodes
- Faster: Nodes stay configured, just reallocate
- Existing Code: Uses production node pool system
- Backwards Compatible: Default behavior unchanged (opt-in with USE_NODE_POOL=true)

## Testing

### Local Testing
```bash
# 1. Provision with node pool
export USE_NODE_POOL=true
./byoh.sh apply

# 2. Verify pool created
oc get configmap windows-node-pool -n openshift-windows-machine-config-operator -o yaml

# 3. Run BYOH test (it will auto-allocate from pool)
# 4. Verify node released back after test

# 5. Clean up
./byoh.sh destroy
```

## Migration Path

**Phase 1**: This PR (terraform-windows-provisioner)
- Add node pool ConfigMap support
- Test locally

**Phase 2**: Release repository
- Update Prow job definitions to set USE_NODE_POOL=true
- Monitor for regressions

**Phase 3**: Validation
- Run full WC-BYOH test suite
- Verify all 5 tests pass consistently

## Related

- [WINC-1835](https://redhat.atlassian.net/browse/WINC-1835): Node pool integration (this issue)
- [WINC-1837](https://redhat.atlassian.net/browse/WINC-1837): Original terraform detection attempt
- openshift/openshift-tests-private#29631: Closed - caused regression, led to this solution

## Documentation

See BYOH_PROW_INTEGRATION.md for:
- Detailed architecture explanation
- Root cause analysis of previous approach
- Complete integration guide
- Future enhancements
