### PR TITLE
WINC-1928: Add Windows Server 2025 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Optional configuration:
 # Deploy 2 Windows Server 2022 nodes
 ./byoh.sh apply mywindows 2
 
-# Deploy 4 Windows Server 2019 nodes
-./byoh.sh apply mywindows 4 '' 2019
+# Deploy 2 Windows Server 2025 nodes
+./byoh.sh apply mywindows 2 '' 2025
 ```
 
 ### 4. Destroy Windows Nodes When Done
@@ -89,7 +89,7 @@ Optional configuration:
 | `NAME` | Base name for instances | byoh-winc | No |
 | `NUM_WORKERS` | Number of workers | 2 | No |
 | `FOLDER_SUFFIX` | Temporary folder suffix | "" | No |
-| `WINDOWS_VERSION` | Windows Server version (2019/2022) | 2022 | No |
+| `WINDOWS_VERSION` | Windows Server version (2022/2025) | 2022 | No |
 
 ### Basic Commands
 
@@ -116,8 +116,8 @@ Optional configuration:
 ### Examples
 
 ```bash
-# Single Windows 2019 instance
-./byoh.sh apply myapp 1 '' 2019
+# Single Windows 2025 instance
+./byoh.sh apply myapp 1 '' 2025
 
 # 4 Windows 2022 instances with custom name
 ./byoh.sh apply production-win 4
@@ -250,8 +250,8 @@ See [configs/examples/](configs/examples/) for platform-specific examples:
 | `WINDOWS_ADMIN_USERNAME` | Windows administrator username | Platform-specific: Azure=`capi`, Others=`Administrator` |
 | `WINDOWS_CONTAINER_LOGS_PORT` | Container logs port | 10250 |
 | `AZURE_VM_EXTENSION_HANDLER_VERSION` | Azure VM extension version | 1.9 |
-| `AZURE_2019_IMAGE_VERSION` | Azure Win 2019 image version | latest |
 | `AZURE_2022_IMAGE_VERSION` | Azure Win 2022 image version | latest |
+| `AZURE_2025_IMAGE_VERSION` | Azure Win 2025 image version | latest |
 | `AWS_INSTANCE_TYPE` | AWS instance type | m5a.large |
 | `AWS_WINDOWS_AMI` | AWS Windows AMI override | (auto-detected) |
 | `AWS_DEFAULT_REGION` | AWS region override | (auto-detected) |
@@ -312,13 +312,13 @@ TF_VAR_custom_security_group=sg-12345
 
 - Requires pre-configured Windows templates
 - vCenter credentials from cluster secrets
-- Template names: `Windows-Server-2019-Template`, `Windows-Server-2022-Template`
+- Template names: `Windows-Server-2022-Template`, `Windows-Server-2025-Template`
 
 ### Nutanix
 
 - Requires pre-configured Windows images in Prism Central
 - Cluster and subnet UUIDs auto-detected
-- Image names: `Windows-Server-2019`, `Windows-Server-2022`
+- Image names: `Windows-Server-2022`, `Windows-Server-2025`
 
 ### Bare Metal (None)
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -31,7 +31,7 @@ variable winc_instance_type {
     default = "Standard_D2s_v3"
 }
 
-# Windows SKU (e.g., 2019-datacenter-smalldisk, 2022-datacenter-smalldisk)
+# Windows SKU (e.g., 2022-datacenter-smalldisk, 2025-datacenter-smalldisk)
 variable winc_worker_sku {
     type = string
 }

--- a/byoh.sh
+++ b/byoh.sh
@@ -57,7 +57,7 @@ Parameters:
                     Default: "" (empty)
 
     WINDOWS_VERSION Windows Server version to use
-                    Accepted: 2019, 2022
+                    Accepted: 2022, 2025
                     Default: 2022
 
 Supported Platforms:
@@ -69,15 +69,15 @@ Supported Platforms:
     - None (baremetal)
 
 Examples:
-    # Create single Windows 2019 instance
-    ./byoh.sh apply byoh 1 '' 2019
-
     # Create 4 Windows 2022 instances
     ./byoh.sh apply winc-byoh 4
 
+    # Create Windows 2025 instances
+    ./byoh.sh apply byoh-winc 2 '' 2025
+
     # Multiple platform-specific runs
-    ./byoh.sh apply byoh-winc 2 '-az2019'    # Azure 2019
     ./byoh.sh apply byoh-winc 2 '-az2022'    # Azure 2022
+    ./byoh.sh apply byoh-winc 2 '-az2025'    # Azure 2025
 
     # Show Terraform arguments without applying
     ./byoh.sh arguments byoh-winc 2

--- a/configs/defaults.conf
+++ b/configs/defaults.conf
@@ -28,8 +28,8 @@ WMCO_IDENTIFIER_TYPE=ip
 # Azure-specific Configuration
 # Note: These can be overridden for different image versions
 AZURE_VM_EXTENSION_HANDLER_VERSION=1.9
-AZURE_2019_IMAGE_VERSION=latest
 AZURE_2022_IMAGE_VERSION=latest
+AZURE_2025_IMAGE_VERSION=latest
 
 # Instance Tags (customizable for your environment)
 ENVIRONMENT_TAG=development

--- a/configs/examples/azure.conf.example
+++ b/configs/examples/azure.conf.example
@@ -18,10 +18,10 @@ AZURE_VM_EXTENSION_HANDLER_VERSION=1.9
 
 # Azure Windows Image Versions
 # Use specific versions for consistency, or 'latest' for most recent
-# Windows Server 2019
-AZURE_2019_IMAGE_VERSION=17763.4499.230606
 # Windows Server 2022
 AZURE_2022_IMAGE_VERSION=20348.1787.230621
+# Windows Server 2025
+AZURE_2025_IMAGE_VERSION=latest
 
 # Instance Tags
 ENVIRONMENT_TAG=production

--- a/configs/examples/defaults.conf.example
+++ b/configs/examples/defaults.conf.example
@@ -34,8 +34,8 @@ WINC_SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... your-email@examp
 
 # Azure-specific
 # Use specific image versions instead of 'latest'
-# AZURE_2019_IMAGE_VERSION=17763.4499.230606
 # AZURE_2022_IMAGE_VERSION=20348.1787.230621
+# AZURE_2025_IMAGE_VERSION=latest
 # AZURE_VM_EXTENSION_HANDLER_VERSION=1.9
 
 # Instance Tags

--- a/configs/examples/nutanix.conf.example
+++ b/configs/examples/nutanix.conf.example
@@ -13,8 +13,8 @@ NUTANIX_DISK_SIZE_GB=120
 
 # Nutanix Image Names
 # These should match your pre-configured Windows images in Prism Central
-NUTANIX_2019_IMAGE_NAME=Windows-Server-2019
 NUTANIX_2022_IMAGE_NAME=Windows-Server-2022
+NUTANIX_2025_IMAGE_NAME=Windows-Server-2025
 
 # Instance Tags
 ENVIRONMENT_TAG=production

--- a/configs/examples/vsphere.conf.example
+++ b/configs/examples/vsphere.conf.example
@@ -8,8 +8,8 @@ WINC_SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... your-email@examp
 # vSphere Configuration (most values auto-detected from cluster)
 # Windows template path (use the template you want to clone from)
 # Examples:
-#   VSPHERE_WINDOWS_TEMPLATE=Windows-Server-2019-Template
 #   VSPHERE_WINDOWS_TEMPLATE=Windows-Server-2022-Template
+#   VSPHERE_WINDOWS_TEMPLATE=Windows-Server-2025-Template
 #   VSPHERE_WINDOWS_TEMPLATE=windows-golden-images/windows-server-2022-template-qe-20241104
 VSPHERE_WINDOWS_TEMPLATE=Windows-Server-2022-Template
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -125,8 +125,8 @@ function create_user_config() {
 
 # Azure-specific
 # AZURE_VM_EXTENSION_HANDLER_VERSION=1.9
-# AZURE_2019_IMAGE_VERSION=latest
 # AZURE_2022_IMAGE_VERSION=latest
+# AZURE_2025_IMAGE_VERSION=latest
 
 # AWS Configuration
 # AWS_PROFILE - For SAML/SSO, set to your profile name (e.g., "saml")

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -520,8 +520,8 @@ function get_azure_terraform_args() {
     local resource_prefix="${ARM_RESOURCE_PREFIX}"
     local sku="2022-datacenter-smalldisk"
 
-    if [[ "$win_version" == "2019" ]]; then
-        sku="2019-datacenter-smalldisk"
+    if [[ "$win_version" == "2025" ]]; then
+        sku="2025-datacenter-smalldisk"
     fi
 
     # Get configuration values

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -3,7 +3,7 @@
 
 # Supported actions and versions
 declare -ra SUPPORTED_ACTIONS=("apply" "destroy" "arguments" "configmap" "clean" "help")
-declare -ra SUPPORTED_WIN_VERSIONS=("2019" "2022")
+declare -ra SUPPORTED_WIN_VERSIONS=("2022" "2025")
 
 # Validate action parameter
 function validate_action() {

--- a/none/variables.tf
+++ b/none/variables.tf
@@ -17,12 +17,12 @@ variable "winc_instance_type" {
 }
 
 variable "winc_version" {
-  description = "Windows Server version for the AMI (2019 or 2022)"
+  description = "Windows Server version for the AMI (2022 or 2025)"
   type        = string
   default     = "2022"
   validation {
-    condition     = contains(["2019", "2022"], var.winc_version)
-    error_message = "Allowed values for winc_version are '2019' or '2022'."
+    condition     = contains(["2022", "2025"], var.winc_version)
+    error_message = "Allowed values for winc_version are '2022' or '2025'."
   }
 }
 


### PR DESCRIPTION
## Summary
- Add Windows Server 2025 support across all platforms
- Drop Windows Server 2019 which has reached End of Life (EOL)
- Supported versions are now: 2022 and 2025

## Changes
- Add Azure SKU mapping for 2025-datacenter-smalldisk
- Update Terraform variable validation (none platform) to accept 2022/2025
- Remove all Server 2019 references from code, configs, docs, and examples
- Update documentation and config examples with Server 2025 entries