### PR TITLE
Fix owners to winc team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
 approvers:
   - rrasouli
-  - weinliu 
+  - "winc-approvers"
 reviewers:
   - rrasouli
-  - weinliu
-  - jrvaldes 
-  - sebsoto
+  - "winc-reviewers"
 options:
   no_parent_owners: true

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,7 @@
+aliases:
+  winc-approvers:
+    - mansikulkarni96
+    - jrvaldes
+  winc-reviewers:
+    - mansikulkarni96
+    - jrvaldes


### PR DESCRIPTION
Updating Owners to WINC team label, removing individuals that are no longer part of WinC team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration to reflect current team structure.

---

**Note:** This change is internal to development processes and has no impact on end-user features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->